### PR TITLE
Fix division by zero error in /money stats command when no accounts are registered

### DIFF
--- a/src/main/java/io/github/townyadvanced/iconomy/commands/MoneyCommand.java
+++ b/src/main/java/io/github/townyadvanced/iconomy/commands/MoneyCommand.java
@@ -401,7 +401,7 @@ public class MoneyCommand implements TabExecutor {
 
 		Messaging.send(sender, LangStrings.statsHeader());
 		Messaging.send(sender, LangStrings.statsTotal(Settings.getCurrencyName(), Settings.format(TCOH)));
-		Messaging.send(sender, LangStrings.statsAverage(Settings.getCurrencyName(), Settings.format(TCOH / totalAccounts)));
+		Messaging.send(sender, LangStrings.statsAverage(Settings.getCurrencyName(), Settings.format(totalAccounts != 0 ? TCOH / totalAccounts : 0)));
 		Messaging.send(sender, LangStrings.statsAccounts(String.valueOf(accounts)));
 	}
 


### PR DESCRIPTION
This PR addresses a division by zero during the calculation of the average account balance that occurred when executing the `/money stats` command from the console without any registered accounts.