### PR TITLE
Enabled console to run /money rank by removing Player casting

### DIFF
--- a/src/main/java/io/github/townyadvanced/iconomy/commands/MoneyCommand.java
+++ b/src/main/java/io/github/townyadvanced/iconomy/commands/MoneyCommand.java
@@ -285,7 +285,7 @@ public class MoneyCommand implements TabExecutor {
 			throw new CommandException(LangStrings.noAccountFound(accountName));
 
 		String rank = String.valueOf(account.getRank());
-		boolean isSelf = ((Player) viewing).getName().equalsIgnoreCase(accountName);
+		boolean isSelf = viewing.getName().equalsIgnoreCase(accountName);
 
 		String message = isSelf ? LangStrings.personalRank(rank) : LangStrings.playerRank(accountName, rank);
 		Messaging.sendMoneyPrefixedMsg(viewing, message);


### PR DESCRIPTION
Fixes `/money rank PLAYER` command to allow execution from the console by removing the casting of the sender to Player. I have tested this, and there is no change in functionality from the player's perspective and it is also now able to be ran from the console. (It still does not allow no player argument to be provided, as it should)